### PR TITLE
feat(getPinClaims): Added REST API endpoint to get last 20 claims

### DIFF
--- a/src/adapters/ipfs/ipfs-coord.js
+++ b/src/adapters/ipfs/ipfs-coord.js
@@ -48,7 +48,7 @@ class IpfsCoordAdapter {
 
     // Wait for the BCH wallet to create the wallet.
     await this.wallet.walletInfoPromise
-    console.log('ping01')
+
     // If configured as a Circuit Relay, get the public IP addresses for this node.
     if (this.config.isCircuitRelay) {
       try {
@@ -87,12 +87,12 @@ class IpfsCoordAdapter {
     // if (this.config.isProduction) {
     //   ipfsCoordOptions.nodeType = 'external'
     // }
-    console.log('ping02')
+
     this.ipfsCoord = new this.IpfsCoord(ipfsCoordOptions)
 
     // Wait for the ipfs-coord library to signal that it is ready.
     await this.ipfsCoord.start()
-    console.log('ping03')
+
     // Signal that this adapter is ready.
     this.isReady = true
 

--- a/src/adapters/localdb/models/pins.js
+++ b/src/adapters/localdb/models/pins.js
@@ -18,7 +18,8 @@ const Pin = new mongoose.Schema({
   tokensBurned: { type: Number },
   validClaim: { type: Boolean, default: null },
   dataPinned: { type: Boolean, default: false },
-  address: { type: String, default: null }
+  address: { type: String, default: null },
+  recordTime: { type: Number }
 })
 
 export default mongoose.model('pin', Pin)

--- a/src/controllers/rest-api/ipfs/controller.js
+++ b/src/controllers/rest-api/ipfs/controller.js
@@ -110,7 +110,7 @@ class IpfsRESTControllerLib {
   async pinClaim (ctx) {
     try {
       const body = ctx.request.body
-      console.log('pinClaim() body: ', body)
+      console.log('---->pinClaim() body: ', body)
 
       const result = await this.useCases.ipfs.processPinClaim(body)
 

--- a/src/controllers/rest-api/ipfs/controller.js
+++ b/src/controllers/rest-api/ipfs/controller.js
@@ -35,6 +35,7 @@ class IpfsRESTControllerLib {
     this.downloadCid = this.downloadCid.bind(this)
     this.getThisNode = this.getThisNode.bind(this)
     this.downloadFile = this.downloadFile.bind(this)
+    this.getPins = this.getPins.bind(this)
   }
 
   /**
@@ -110,7 +111,7 @@ class IpfsRESTControllerLib {
   async pinClaim (ctx) {
     try {
       const body = ctx.request.body
-      console.log('---->pinClaim() body: ', body)
+      console.log('pinClaim() body: ', body)
 
       const result = await this.useCases.ipfs.processPinClaim(body)
 
@@ -186,6 +187,18 @@ class IpfsRESTControllerLib {
       return file
     } catch (err) {
       wlogger.error('Error in ipfs/controller.js/downloadFile(): ', err)
+      this.handleError(ctx, err)
+    }
+  }
+
+  // Get a paginated list of the latest pin claims.
+  async getPins (ctx) {
+    try {
+      const pins = await this.useCases.ipfs.getPinClaims()
+
+      ctx.body = pins
+    } catch (err) {
+      wlogger.error('Error in ipfs/controller.js/getPins(): ', err)
       this.handleError(ctx, err)
     }
   }

--- a/src/controllers/rest-api/ipfs/index.js
+++ b/src/controllers/rest-api/ipfs/index.js
@@ -60,6 +60,7 @@ class IpfsRouter {
     this.router.get('/download/:cid', this.ipfsRESTController.downloadCid)
     this.router.get('/node', this.ipfsRESTController.getThisNode)
     this.router.get('/download/:cid', this.ipfsRESTController.downloadFile)
+    this.router.get('/pins', this.ipfsRESTController.getPins)
 
     // Attach the Controller routes to the Koa app.
     app.use(this.router.routes())

--- a/src/entities/pin.js
+++ b/src/entities/pin.js
@@ -23,6 +23,9 @@ class Pin {
       throw new Error("Property 'address' must be a string!")
     }
 
+    const now = new Date()
+    const recordTime = now.getTime()
+
     const pinData = {
       proofOfBurnTxid,
       cid,
@@ -33,7 +36,8 @@ class Pin {
       tokensBurned,
       address,
       validClaim: null,
-      dataPinned: false
+      dataPinned: false,
+      recordTime
     }
 
     return pinData

--- a/src/use-cases/ipfs.js
+++ b/src/use-cases/ipfs.js
@@ -136,7 +136,7 @@ class IpfsUseCases {
   // This function is called by the pinCids() in the Timer Controller.
   async pinCid (pinData = {}) {
     try {
-      console.log('pinData: ', pinData)
+      console.log('---->pinData: ', pinData)
 
       const { cid, tokensBurned } = pinData
 

--- a/src/use-cases/ipfs.js
+++ b/src/use-cases/ipfs.js
@@ -459,8 +459,8 @@ class IpfsUseCases {
         const thisPin = sortedPins[i]
 
         // Extract selected properties for export.
-        const { proofOfBurnTxid, cid, claimTxid, address, filename, validClaim, dataPinned, tokensBurned } = thisPin
-        const outObj = { proofOfBurnTxid, cid, claimTxid, address, filename, validClaim, dataPinned, tokensBurned }
+        const { proofOfBurnTxid, cid, claimTxid, address, filename, validClaim, dataPinned, tokensBurned, recordTime } = thisPin
+        const outObj = { proofOfBurnTxid, cid, claimTxid, address, filename, validClaim, dataPinned, tokensBurned, recordTime }
 
         pins.push(outObj)
       }

--- a/src/use-cases/ipfs.js
+++ b/src/use-cases/ipfs.js
@@ -45,6 +45,7 @@ class IpfsUseCases {
     this.getPinStatus = this.getPinStatus.bind(this)
     this.downloadCid = this.downloadCid.bind(this)
     this.validateSizeAndPayment = this.validateSizeAndPayment.bind(this)
+    this.getPinClaims = this.getPinClaims.bind(this)
 
     // State
     this.promiseTracker = {} // track promises for pinning content
@@ -136,7 +137,7 @@ class IpfsUseCases {
   // This function is called by the pinCids() in the Timer Controller.
   async pinCid (pinData = {}) {
     try {
-      console.log('---->pinData: ', pinData)
+      console.log('pinData: ', pinData)
 
       const { cid, tokensBurned } = pinData
 
@@ -433,6 +434,47 @@ class IpfsUseCases {
       return { filename, readStream }
     } catch (err) {
       console.error('Error in use-cases/ipfs.js/dowloadCid()')
+      throw err
+    }
+  }
+
+  // Get the last 20 pin claim entries added to the database.
+  async getPinClaims (inObj = {}) {
+    try {
+      console.log('inObj: ', inObj)
+
+      const Pins = this.adapters.localdb.Pins
+
+      const getPins = (Model) => {
+        return new Promise((resolve, reject) => {
+          const pins = []
+          Model.find({}).sort('-date').exec((err, docs) => {
+            if (err) reject(err)
+
+            console.log('docs: ', docs)
+            console.log('docs.length: ', docs.length)
+            let pinLen = 20
+
+            if (docs.length < 20) { pinLen = docs.length }
+
+            for (let i = 0; i < pinLen; i++) {
+              pins.push(docs[i])
+            }
+
+            resolve(pins)
+          })
+        })
+      }
+
+      const pins = await getPins(Pins)
+      console.log('pins: ', pins)
+
+      return {
+        success: true,
+        pins
+      }
+    } catch (err) {
+      console.error('Error in use-cases/ipfs.js/getPinClaims()')
       throw err
     }
   }

--- a/src/use-cases/ipfs.js
+++ b/src/use-cases/ipfs.js
@@ -452,11 +452,10 @@ class IpfsUseCases {
       })
 
       let pinLen = 20
-      if(sortedPins.length < 20)
-        pinLen = sortedPins.length
+      if (sortedPins.length < 20) { pinLen = sortedPins.length }
 
       const pins = []
-      for(let i=0; i<pinLen; i++) {
+      for (let i = 0; i < pinLen; i++) {
         pins.push(sortedPins[i])
       }
 

--- a/src/use-cases/ipfs.js
+++ b/src/use-cases/ipfs.js
@@ -456,7 +456,13 @@ class IpfsUseCases {
 
       const pins = []
       for (let i = 0; i < pinLen; i++) {
-        pins.push(sortedPins[i])
+        const thisPin = sortedPins[i]
+
+        // Extract selected properties for export.
+        const { proofOfBurnTxid, cid, claimTxid, address, filename, validClaim, dataPinned, tokensBurned } = thisPin
+        const outObj = { proofOfBurnTxid, cid, claimTxid, address, filename, validClaim, dataPinned, tokensBurned }
+
+        pins.push(outObj)
       }
 
       console.log('pins: ', pins)

--- a/src/use-cases/ipfs.js
+++ b/src/use-cases/ipfs.js
@@ -445,28 +445,21 @@ class IpfsUseCases {
 
       const Pins = this.adapters.localdb.Pins
 
-      const getPins = (Model) => {
-        return new Promise((resolve, reject) => {
-          const pins = []
-          Model.find({}).sort('-date').exec((err, docs) => {
-            if (err) reject(err)
+      const unsortedPins = await Pins.find({})
 
-            console.log('docs: ', docs)
-            console.log('docs.length: ', docs.length)
-            let pinLen = 20
+      const sortedPins = unsortedPins.sort(function (a, b) {
+        return b.recordTime - a.recordTime
+      })
 
-            if (docs.length < 20) { pinLen = docs.length }
+      let pinLen = 20
+      if(sortedPins.length < 20)
+        pinLen = sortedPins.length
 
-            for (let i = 0; i < pinLen; i++) {
-              pins.push(docs[i])
-            }
-
-            resolve(pins)
-          })
-        })
+      const pins = []
+      for(let i=0; i<pinLen; i++) {
+        pins.push(sortedPins[i])
       }
 
-      const pins = await getPins(Pins)
       console.log('pins: ', pins)
 
       return {

--- a/test/unit/controllers/rest-api/ipfs/ipfs.rest.controller.unit.js
+++ b/test/unit/controllers/rest-api/ipfs/ipfs.rest.controller.unit.js
@@ -284,6 +284,41 @@ describe('#IPFS REST API', () => {
     })
   })
 
+  describe('#GET /pins', () => {
+    it('should return 422 status on biz logic error', async () => {
+      try {
+        // Force an error
+        sandbox.stub(uut.useCases.ipfs, 'getPinClaims').rejects(new Error('test error'))
+
+        ctx.params = {
+          cid: 'fake-cid'
+        }
+
+        await uut.getPins(ctx)
+
+        assert.fail('Unexpected result')
+      } catch (err) {
+        console.log(err)
+        assert.equal(err.status, 422)
+        assert.include(err.message, 'test error')
+      }
+    })
+
+    it('should return 200 status on success', async () => {
+      // Mock dependencies
+      sandbox.stub(uut.useCases.ipfs, 'getPinClaims').resolves({ success: true, pins: [] })
+
+      ctx.params = {
+        cid: 'fake-cid'
+      }
+
+      await uut.getPins(ctx)
+      // console.log('ctx.body: ', ctx.body)
+
+      assert.isObject(ctx.body)
+    })
+  })
+
   describe('#handleError', () => {
     it('should still throw error if there is no message', () => {
       try {

--- a/test/unit/mocks/use-cases/index.js
+++ b/test/unit/mocks/use-cases/index.js
@@ -47,6 +47,10 @@ class IpfsUseCaseMock {
   async downloadCid() {
     return true
   }
+
+  async getPinClaims() {
+    return true
+  }
 }
 
 class UseCasesMock {

--- a/test/unit/use-cases/ipfs.use-case.unit.js
+++ b/test/unit/use-cases/ipfs.use-case.unit.js
@@ -412,4 +412,38 @@ describe('#ipfs-use-case', () => {
       await uut.validateSizeAndPayment({ fileSize, tokensBurned })
     })
   })
+
+  describe('#getPinClaims', () => {
+    it('should return the last 20 pin claims', async () => {
+      // Create mock data
+      const pins = []
+      for (let i = 0; i < 40; i++) {
+        pins.push({
+          recordTime: i,
+          proofOfBurnTxid: 'fake-txid',
+          cid: 'fake-cid',
+          claimTxid: 'fake-txid',
+          address: 'fake-address',
+          filename: 'fake-filename',
+          validClaim: true,
+          dataPinned: true,
+          tokensBurned: 0.08335232
+        })
+      }
+
+      // Mock depenedencies and force desired code path.
+      sandbox.stub(uut.adapters.localdb.Pins, 'find').resolves(pins)
+
+      const result = await uut.getPinClaims()
+
+      assert.property(result, 'success')
+      assert.property(result, 'pins')
+
+      assert.equal(result.success, true)
+      assert.equal(result.pins.length, 20)
+
+      // Assert that the newest entry is first.
+      assert.equal(result.pins[0].recordTime, 39)
+    })
+  })
 })


### PR DESCRIPTION
This PR adds a new `GET /ipfs/pins` REST API endpoint that retrieves the most recent 20 pin claims processed by the software. This data will be useful for creating a dashboard. 

Here is an example of the output:

```
[
  {
    proofOfBurnTxid: 'a2fa2b8a022c653d1d399fc1c4d0343d6cc6e3629615ded6fa41282826acaf08',
    cid: 'bafkreiafna2l5zxmc67wpjplr3hgg522sdx6eavd6xxfhg4ufbvpz24nam',
    claimTxid: '73d08625c9264e40846fe87512fab5ddb31490f840628a84a58b4730d39b0cd0',
    address: 'bitcoincash:qzz4a34kpqeswwljxgdhuxh77jxx0zdnwv84866v2y',
    filename: 'grey-wizard.jpg',
    validClaim: true,
    dataPinned: true,
    tokensBurned: 0.08335233,
    recordTime: 1709266397227
  },
  {
    proofOfBurnTxid: '4b69a50f0bbdeace17b0a87a653fc4a044684ec4db6fc04da5beaa850ffd20e9',
    cid: 'bafkreiahhhyxu63pxvtrctbe32nuokfg37pyhssofawgurgfiz4mzn2uei',
    claimTxid: '3906f59dceabd33067d21ec828d8bfaf60446005c659371ab69f9697fa1d8651',
    address: 'bitcoincash:qzz4a34kpqeswwljxgdhuxh77jxx0zdnwv84866v2y',
    filename: 'screenshot-from-2024-02-24-08-49-47.png',
    validClaim: true,
    dataPinned: true,
    tokensBurned: 0.08335233,
    recordTime: 1709265372645
  },
...
  {
    proofOfBurnTxid: '868e92005a323b322f471ae6570085c9f56d9858ab47cec33e5f009551b44e22',
    cid: 'bafkreihish3wy6wvstocwpk7r2c57ihct23gr57gm2oexzzrvrwa4tiayy',
    claimTxid: '57e7225fade41d5950806d9f3ce6243eff87206604d1f3b3026bee58c64203cc',
    address: 'bitcoincash:qzz4a34kpqeswwljxgdhuxh77jxx0zdnwv84866v2y',
    filename: 'screenshot-from-2024-02-23-20-50-00.png',
    validClaim: true,
    dataPinned: true,
    tokensBurned: 0.08335233,
    recordTime: 1709265365847
  }
]
```