### PR TITLE
Fix content link

### DIFF
--- a/src/use-cases/ipfs.js
+++ b/src/use-cases/ipfs.js
@@ -602,7 +602,7 @@ class IpfsUseCases {
           // List all paths excluding root path.
           if (cont.path !== cid) {
             // Add links to the gateway with the format  cid/:filename
-            stream.push(`<a href='http://${this.config.domainName}/ipfs/view/${cid}/${cont.name}' >/${cont.name} ( CID:  ${cont.cid} )</a><hr />`)
+            stream.push(`<a href='${this.config.domainName}/ipfs/view/${cid}/${cont.name}' >/${cont.name} ( CID:  ${cont.cid} )</a><hr />`)
           }
         }
 


### PR DESCRIPTION
In this PR I fixed the `src` of the link, since it repeated the `http` protocol, and redirected to `http://https//`
so I removed the `http://` protocol, leaving only the one obtained by the `config.domainName` variable