### PR TITLE
web2 interface and rejecting low PoB

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ This web server spins up an embedded IPFS ([Helia](https://github.com/ipfs/helia
 
 ## Requirements
 
-- node **^16.20.2**
-- npm **^8.19.4**
-- Docker **^20.10.8**
+- node **^20.16.0**
+- npm **^10.8.1**
+- Docker **^24.0.7**
 - Docker Compose **^1.27.4**
 
 ## Installation

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "libp2p": "1.9.1",
         "line-reader": "0.4.0",
         "mime-types": "2.1.35",
-        "minimal-slp-wallet": "5.11.1",
+        "minimal-slp-wallet": "5.11.3",
         "mongoose": "5.13.14",
         "node-fetch": "npm:@achingbrain/node-fetch@2.6.7",
         "nodemailer": "6.7.5",
@@ -2650,246 +2650,6 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.16.17",
-      "resolved": "http://94.130.170.209:4873/@esbuild%2fandroid-arm/-/android-arm-0.16.17.tgz",
-      "integrity": "sha512-N9x1CMXVhtWEAMS7pNNONyA14f71VPQN9Cnavj1XQh6T7bskqiLLrSca4O0Vr8Wdcga943eThxnVp3JLnBMYtw==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.16.17",
-      "resolved": "http://94.130.170.209:4873/@esbuild%2fandroid-arm64/-/android-arm64-0.16.17.tgz",
-      "integrity": "sha512-MIGl6p5sc3RDTLLkYL1MyL8BMRN4tLMRCn+yRJJmEDvYZ2M7tmAf80hx1kbNEUX2KJ50RRtxZ4JHLvCfuB6kBg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.16.17",
-      "resolved": "http://94.130.170.209:4873/@esbuild%2fandroid-x64/-/android-x64-0.16.17.tgz",
-      "integrity": "sha512-a3kTv3m0Ghh4z1DaFEuEDfz3OLONKuFvI4Xqczqx4BqLyuFaFkuaG4j2MtA6fuWEFeC5x9IvqnX7drmRq/fyAQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.16.17",
-      "resolved": "http://94.130.170.209:4873/@esbuild%2fdarwin-arm64/-/darwin-arm64-0.16.17.tgz",
-      "integrity": "sha512-/2agbUEfmxWHi9ARTX6OQ/KgXnOWfsNlTeLcoV7HSuSTv63E4DqtAc+2XqGw1KHxKMHGZgbVCZge7HXWX9Vn+w==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.16.17",
-      "resolved": "http://94.130.170.209:4873/@esbuild%2fdarwin-x64/-/darwin-x64-0.16.17.tgz",
-      "integrity": "sha512-2By45OBHulkd9Svy5IOCZt376Aa2oOkiE9QWUK9fe6Tb+WDr8hXL3dpqi+DeLiMed8tVXspzsTAvd0jUl96wmg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.16.17",
-      "resolved": "http://94.130.170.209:4873/@esbuild%2ffreebsd-arm64/-/freebsd-arm64-0.16.17.tgz",
-      "integrity": "sha512-mt+cxZe1tVx489VTb4mBAOo2aKSnJ33L9fr25JXpqQqzbUIw/yzIzi+NHwAXK2qYV1lEFp4OoVeThGjUbmWmdw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.16.17",
-      "resolved": "http://94.130.170.209:4873/@esbuild%2ffreebsd-x64/-/freebsd-x64-0.16.17.tgz",
-      "integrity": "sha512-8ScTdNJl5idAKjH8zGAsN7RuWcyHG3BAvMNpKOBaqqR7EbUhhVHOqXRdL7oZvz8WNHL2pr5+eIT5c65kA6NHug==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.16.17",
-      "resolved": "http://94.130.170.209:4873/@esbuild%2flinux-arm/-/linux-arm-0.16.17.tgz",
-      "integrity": "sha512-iihzrWbD4gIT7j3caMzKb/RsFFHCwqqbrbH9SqUSRrdXkXaygSZCZg1FybsZz57Ju7N/SHEgPyaR0LZ8Zbe9gQ==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.16.17",
-      "resolved": "http://94.130.170.209:4873/@esbuild%2flinux-arm64/-/linux-arm64-0.16.17.tgz",
-      "integrity": "sha512-7S8gJnSlqKGVJunnMCrXHU9Q8Q/tQIxk/xL8BqAP64wchPCTzuM6W3Ra8cIa1HIflAvDnNOt2jaL17vaW+1V0g==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.16.17",
-      "resolved": "http://94.130.170.209:4873/@esbuild%2flinux-ia32/-/linux-ia32-0.16.17.tgz",
-      "integrity": "sha512-kiX69+wcPAdgl3Lonh1VI7MBr16nktEvOfViszBSxygRQqSpzv7BffMKRPMFwzeJGPxcio0pdD3kYQGpqQ2SSg==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.16.17",
-      "resolved": "http://94.130.170.209:4873/@esbuild%2flinux-loong64/-/linux-loong64-0.16.17.tgz",
-      "integrity": "sha512-dTzNnQwembNDhd654cA4QhbS9uDdXC3TKqMJjgOWsC0yNCbpzfWoXdZvp0mY7HU6nzk5E0zpRGGx3qoQg8T2DQ==",
-      "cpu": [
-        "loong64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.16.17",
-      "resolved": "http://94.130.170.209:4873/@esbuild%2flinux-mips64el/-/linux-mips64el-0.16.17.tgz",
-      "integrity": "sha512-ezbDkp2nDl0PfIUn0CsQ30kxfcLTlcx4Foz2kYv8qdC6ia2oX5Q3E/8m6lq84Dj/6b0FrkgD582fJMIfHhJfSw==",
-      "cpu": [
-        "mips64el"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.16.17",
-      "resolved": "http://94.130.170.209:4873/@esbuild%2flinux-ppc64/-/linux-ppc64-0.16.17.tgz",
-      "integrity": "sha512-dzS678gYD1lJsW73zrFhDApLVdM3cUF2MvAa1D8K8KtcSKdLBPP4zZSLy6LFZ0jYqQdQ29bjAHJDgz0rVbLB3g==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.16.17",
-      "resolved": "http://94.130.170.209:4873/@esbuild%2flinux-riscv64/-/linux-riscv64-0.16.17.tgz",
-      "integrity": "sha512-ylNlVsxuFjZK8DQtNUwiMskh6nT0vI7kYl/4fZgV1llP5d6+HIeL/vmmm3jpuoo8+NuXjQVZxmKuhDApK0/cKw==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.16.17",
-      "resolved": "http://94.130.170.209:4873/@esbuild%2flinux-s390x/-/linux-s390x-0.16.17.tgz",
-      "integrity": "sha512-gzy7nUTO4UA4oZ2wAMXPNBGTzZFP7mss3aKR2hH+/4UUkCOyqmjXiKpzGrY2TlEUhbbejzXVKKGazYcQTZWA/w==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@esbuild/linux-x64": {
       "version": "0.16.17",
       "resolved": "http://94.130.170.209:4873/@esbuild%2flinux-x64/-/linux-x64-0.16.17.tgz",
@@ -2901,102 +2661,6 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.16.17",
-      "resolved": "http://94.130.170.209:4873/@esbuild%2fnetbsd-x64/-/netbsd-x64-0.16.17.tgz",
-      "integrity": "sha512-/PzmzD/zyAeTUsduZa32bn0ORug+Jd1EGGAUJvqfeixoEISYpGnAezN6lnJoskauoai0Jrs+XSyvDhppCPoKOA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.16.17",
-      "resolved": "http://94.130.170.209:4873/@esbuild%2fopenbsd-x64/-/openbsd-x64-0.16.17.tgz",
-      "integrity": "sha512-2yaWJhvxGEz2RiftSk0UObqJa/b+rIAjnODJgv2GbGGpRwAfpgzyrg1WLK8rqA24mfZa9GvpjLcBBg8JHkoodg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.16.17",
-      "resolved": "http://94.130.170.209:4873/@esbuild%2fsunos-x64/-/sunos-x64-0.16.17.tgz",
-      "integrity": "sha512-xtVUiev38tN0R3g8VhRfN7Zl42YCJvyBhRKw1RJjwE1d2emWTVToPLNEQj/5Qxc6lVFATDiy6LjVHYhIPrLxzw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.16.17",
-      "resolved": "http://94.130.170.209:4873/@esbuild%2fwin32-arm64/-/win32-arm64-0.16.17.tgz",
-      "integrity": "sha512-ga8+JqBDHY4b6fQAmOgtJJue36scANy4l/rL97W+0wYmijhxKetzZdKOJI7olaBaMhWt8Pac2McJdZLxXWUEQw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.16.17",
-      "resolved": "http://94.130.170.209:4873/@esbuild%2fwin32-ia32/-/win32-ia32-0.16.17.tgz",
-      "integrity": "sha512-WnsKaf46uSSF/sZhwnqE4L/F89AYNMiD4YtEcYekBt9Q7nj0DiId2XH2Ng2PHM54qi5oPrQ8luuzGszqi/veig==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.16.17",
-      "resolved": "http://94.130.170.209:4873/@esbuild%2fwin32-x64/-/win32-x64-0.16.17.tgz",
-      "integrity": "sha512-y+EHuSchhL7FjHgvQL/0fnnFmO4T1bhvWANX6gcnqTjtnKWbTvUMCpGnv2+t+31d7RzyEAYAd4u2fnIhHL6N/Q==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
       ],
       "engines": {
         "node": ">=12"
@@ -7835,55 +7499,14 @@
       }
     },
     "node_modules/bch-consumer": {
-      "version": "1.4.5",
-      "resolved": "http://94.130.170.209:4873/bch-consumer/-/bch-consumer-1.4.5.tgz",
-      "integrity": "sha512-hNnhm1q4q+qyJLxyulet5YB6zdTFXx5PUWpuwOqYW/XkoIOpZCyzfFFU/NTB6m5VSQgxmpXYgoqSsYCm+wDbkQ==",
+      "version": "1.4.6",
+      "resolved": "http://94.130.170.209:4873/bch-consumer/-/bch-consumer-1.4.6.tgz",
+      "integrity": "sha512-0R/SPofznZREhMoHHd18nHn97vsjhnqJhIw+olep32aAt93pl9SoKh5i51AtOgHPV/m+o/+WkEWdI7LtIuTVjQ==",
       "license": "MIT",
       "dependencies": {
-        "@psf/bch-js": "6.6.0",
+        "@psf/bch-js": "6.7.3",
         "apidoc": "0.51.0",
         "axios": "0.25.0"
-      }
-    },
-    "node_modules/bch-consumer/node_modules/@psf/bch-js": {
-      "version": "6.6.0",
-      "resolved": "http://94.130.170.209:4873/@psf%2fbch-js/-/bch-js-6.6.0.tgz",
-      "integrity": "sha512-623uPhQQRgf5RusRJVReAxwtSPyMygJKe/qnMBVs8ZWvjFJSr1F+mfS/U8n1dHPV/CHsrcaLUVeSy5ZchNHB6g==",
-      "license": "MIT",
-      "dependencies": {
-        "@chris.troutner/bip32-utils": "1.0.5",
-        "@psf/bip21": "2.0.1",
-        "@psf/bitcoincash-ops": "2.0.0",
-        "@psf/bitcoincashjs-lib": "4.0.3",
-        "@psf/coininfo": "4.0.0",
-        "axios": "0.26.1",
-        "bc-bip68": "1.0.5",
-        "bchaddrjs-slp": "0.2.5",
-        "bigi": "1.4.2",
-        "bignumber.js": "9.0.0",
-        "bip-schnorr": "0.3.0",
-        "bip38": "2.0.2",
-        "bip39": "3.0.2",
-        "bip66": "1.1.5",
-        "bitcoinjs-message": "2.0.0",
-        "bs58": "4.0.1",
-        "ecashaddrjs": "1.0.7",
-        "ini": "1.3.8",
-        "randombytes": "2.0.6",
-        "safe-buffer": "5.1.2",
-        "satoshi-bitcoin": "1.0.4",
-        "slp-mdm": "0.0.6",
-        "slp-parser": "0.0.4",
-        "wif": "2.0.6"
-      }
-    },
-    "node_modules/bch-consumer/node_modules/@psf/bch-js/node_modules/axios": {
-      "version": "0.26.1",
-      "resolved": "http://94.130.170.209:4873/axios/-/axios-0.26.1.tgz",
-      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.14.8"
       }
     },
     "node_modules/bch-consumer/node_modules/apidoc": {
@@ -7957,21 +7580,6 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
-    },
-    "node_modules/bch-consumer/node_modules/randombytes": {
-      "version": "2.0.6",
-      "resolved": "http://94.130.170.209:4873/randombytes/-/randombytes-2.0.6.tgz",
-      "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
-    "node_modules/bch-consumer/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "http://94.130.170.209:4873/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "license": "MIT"
     },
     "node_modules/bch-donation": {
       "version": "1.1.2",
@@ -12313,20 +11921,6 @@
       "resolved": "http://94.130.170.209:4873/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "license": "ISC"
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "http://94.130.170.209:4873/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -16963,15 +16557,15 @@
       }
     },
     "node_modules/minimal-slp-wallet": {
-      "version": "5.11.1",
-      "resolved": "http://94.130.170.209:4873/minimal-slp-wallet/-/minimal-slp-wallet-5.11.1.tgz",
-      "integrity": "sha512-kQp6WS8f9ndoRwucpKtMaLXhOPCp3AK6seBT/TjduzUWfQS4SfXIJfYImVCwogknEW6JJyx5MdWQEWVvFIg/Zg==",
+      "version": "5.11.3",
+      "resolved": "http://94.130.170.209:4873/minimal-slp-wallet/-/minimal-slp-wallet-5.11.3.tgz",
+      "integrity": "sha512-yWi1hMlhis1bfqSBxfysUeEhNPzTLIcazfqd9XmrMVMxbB/AgFT82Gg9xnEjQB8wKtYryF3uc0t3YCAdja7skw==",
       "license": "MIT",
       "dependencies": {
         "@chris.troutner/retry-queue-commonjs": "1.0.8",
         "@psf/bch-js": "6.7.3",
         "apidoc": "0.51.0",
-        "bch-consumer": "1.4.5",
+        "bch-consumer": "1.4.6",
         "bch-donation": "1.1.2",
         "crypto-js": "4.0.0"
       }
@@ -17102,6 +16696,7 @@
       "resolved": "http://94.130.170.209:4873/mkdirp/-/mkdirp-0.5.6.tgz",
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -26453,6 +26048,7 @@
       "resolved": "http://94.130.170.209:4873/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
       "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.11",
         "imurmurhash": "^0.1.4",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "libp2p": "1.9.1",
     "line-reader": "0.4.0",
     "mime-types": "2.1.35",
-    "minimal-slp-wallet": "5.11.1",
+    "minimal-slp-wallet": "5.11.3",
     "mongoose": "5.13.14",
     "node-fetch": "npm:@achingbrain/node-fetch@2.6.7",
     "nodemailer": "6.7.5",

--- a/src/adapters/index.js
+++ b/src/adapters/index.js
@@ -29,7 +29,7 @@ class Adapters {
     this.passport = new Passport()
     this.nodemailer = new Nodemailer()
     this.jsonFiles = new JSONFiles()
-    this.bchjs = new BCHJS()
+    this.bchjs = new BCHJS({ restURL: config.apiServer })
     this.config = config
     this.wallet = new Wallet(localConfig)
     this.writePrice = new WritePrice()

--- a/src/adapters/write-price.js
+++ b/src/adapters/write-price.js
@@ -12,10 +12,20 @@ import WritePriceModel from './localdb/models/write-price.js'
 class WritePrice {
   constructor (localConfig = {}) {
     // Encapsulate dependencies
-    this.wallet = new SlpWallet(undefined, {
-      interface: 'consumer-api',
-      restURL: 'https://free-bch.fullstack.cash'
-    })
+
+    // Switch between web 2 and web 3 interface.
+    if (config.walletInterface === 'web2') {
+      this.wallet = new SlpWallet(undefined, {
+        interface: 'rest-api',
+        restURL: config.apiServer
+      })
+    } else {
+      this.wallet = new SlpWallet(undefined, {
+        interface: 'consumer-api',
+        restURL: 'https://free-bch.fullstack.cash'
+      })
+    }
+
     this.bchjs = undefined // placeholder
     this.ps009 = null // placeholder
     this.axios = axios

--- a/src/use-cases/ipfs.js
+++ b/src/use-cases/ipfs.js
@@ -25,7 +25,9 @@ class IpfsUseCases {
     }
 
     // Encapsulate dependencies
-    if(config.walletInterface === 'web2') {
+
+    // Switch between web 2 and web 3 interface.
+    if (config.walletInterface === 'web2') {
       this.wallet = new Wallet(undefined, {
         interface: 'rest-api',
         restURL: config.apiServer

--- a/src/use-cases/ipfs.js
+++ b/src/use-cases/ipfs.js
@@ -25,10 +25,18 @@ class IpfsUseCases {
     }
 
     // Encapsulate dependencies
-    this.wallet = new Wallet(undefined, {
-      interface: 'consumer-api',
-      restURL: 'https://free-bch.fullstack.cash'
-    })
+    if(config.walletInterface === 'web2') {
+      this.wallet = new Wallet(undefined, {
+        interface: 'rest-api',
+        restURL: config.apiServer
+      })
+    } else {
+      this.wallet = new Wallet(undefined, {
+        interface: 'consumer-api',
+        restURL: 'https://free-bch.fullstack.cash'
+      })
+    }
+
     this.bchjs = this.wallet.bchjs
     this.retryQueue = new RetryQueue({
       concurrency: 20,
@@ -61,6 +69,9 @@ class IpfsUseCases {
   // This function is called by the REST API /ipfs/pin-claim controller.
   async processPinClaim (inObj = {}) {
     try {
+      console.log('processPinClaim() this.wallet.bchjs.restURL: ', this.wallet.bchjs.restURL)
+      console.log('processPinClaim() this.wallet.ar.interface: ', this.wallet.ar.interface)
+
       console.log('processPinClaim() inObj: ', inObj)
       const { proofOfBurnTxid, cid, claimTxid, filename, address } = inObj
 


### PR DESCRIPTION
Main changes in this PR:
- Allows use of web2 infrastructure by talking to bch-api directly, instead of through free-bch.fullstack.cash. This change effects the ipfs.js adapter library that controls the processing of Pin Claims.
- Rejects Pin Claims where the PoB TX does not burn enough PSF tokens.
- Allows reprocessing of Pin Claims so that proper PoB claim can be resubmitted for the same file.
- Updates minimal-slp-wallet to throw an error if it tries to burn more tokens than the wallet contains.