### PR TITLE
fix(pinCid): Removin DB models when they fail validation

### DIFF
--- a/src/use-cases/ipfs.js
+++ b/src/use-cases/ipfs.js
@@ -264,7 +264,7 @@ class IpfsUseCases {
           console.log('existingModel: ', existingModel)
           await existingModel.remove()
           console.log(`Database model for ${cid} deleted.`)
-        } catch(err) {
+        } catch (err) {
           console.error(`Could not delete DB model for CID ${cid}. Error: `, err)
         }
 

--- a/src/use-cases/ipfs.js
+++ b/src/use-cases/ipfs.js
@@ -223,12 +223,8 @@ class IpfsUseCases {
       now = new Date()
       console.log(`Finished download of ${cid} at ${now.toISOString()}`)
 
-      // TODO: Replace this with a validation function.
-      // const isValid = true
-      // let isValid = false
-      // if (fileSize < this.config.maxPinSize) {
-      //   isValid = true
-      // }
+      // Validate that the Pin Claim has appropriate payment, and is under max
+      // size requirement.
       const isValid = await this.validateSizeAndPayment({ fileSize, tokensBurned })
 
       this.pinTrackerCnt--
@@ -260,20 +256,17 @@ class IpfsUseCases {
         // Delete the file from the blockstore
         await this.adapters.ipfs.ipfs.blockstore.delete(cidClass)
 
-        // This code commented out, because I think a better way to handle this
-        // use-case is to allow retry of the CID if the database exists but
-        // the validClaim property is false.
-        // try {
-        //   // Remove pin from database, so that the same file can be pinned
-        //   // again with a larger PoB.
-        //   const Pins = this.adapters.localdb.Pins
-        //   const existingModel = await Pins.findOne({ cid })
-        //   console.log('existingModel: ', existingModel)
-        //   await existingModel.remove()
-        //   console.log(`Database model for ${cid} deleted.`)
-        // } catch(err) {
-        //   console.error(`Could not delete DB model for CID ${cid}. Error: `, err)
-        // }
+        try {
+          // Remove pin from database, so that it does not keep getting downloaded
+          // and pinning retried.
+          const Pins = this.adapters.localdb.Pins
+          const existingModel = await Pins.findOne({ cid })
+          console.log('existingModel: ', existingModel)
+          await existingModel.remove()
+          console.log(`Database model for ${cid} deleted.`)
+        } catch(err) {
+          console.error(`Could not delete DB model for CID ${cid}. Error: `, err)
+        }
 
         pinData.dataPinned = false
         pinData.validClaim = false


### PR DESCRIPTION
I noticed that files that fail Pin Claim validation, are retried ever 30 minutes when the timer controller kicks off. This change deletes Pin Claims from the DB when they fail validation, so that they do not get re-downloaded every 1/2 hour. These files will tend be large and will fail validation because they are either too big (larger than 100MB) or did not have proper PoB to pay for the pinning.