### PR TITLE
Re-process Pin Claim Timer Controller Improvements

### DIFF
--- a/examples/reconsider-cid.js
+++ b/examples/reconsider-cid.js
@@ -1,0 +1,40 @@
+/*
+  This example can be used when a CID is not pinned by a single node, but it
+  has been pinned by other nodes. This happens when the validation on that one
+  node fails. This example can be used to target the specific node and have
+  it re-validate the pin claim.
+*/
+
+// Global npm libraries
+const axios = require('axios')
+
+const CID = 'bafybeihpe6m4r5z5cqwi27wmjuj33wn3f3ipxbe4rcecksicr5k26aqbca'
+const SERVER = 'http://localhost:5031'
+
+async function start () {
+  try {
+    const resp1 = await axios.get(`${SERVER}/ipfs/pin-status/${CID}`)
+    const cidStatus = resp1.data
+    console.log('CID status: ', cidStatus)
+
+    if (cidStatus.dataPinned) {
+      console.log(`CID ${CID} has been pinned by the ipfs-file-pin-service server.`)
+      return
+    }
+
+    console.log(`\n\nAttempting to repin CID: ${CID}`)
+    const pinClaim = {
+      proofOfBurnTxid: cidStatus.proofOfBurnTxid,
+      cid: cidStatus.cid,
+      claimTxid: cidStatus.claimTxid,
+      filename: cidStatus.filename,
+      address: cidStatus.address
+    }
+
+    const resp2 = await axios.post(`${SERVER}/ipfs/pin-claim`, pinClaim)
+    console.log('resp2.data: ', resp2.data)
+  } catch (err) {
+    console.error(err)
+  }
+}
+start()

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@chainsafe/libp2p-gossipsub": "13.1.1",
         "@chainsafe/libp2p-noise": "15.1.1",
         "@chainsafe/libp2p-yamux": "6.0.2",
-        "@chris.troutner/retry-queue": "1.0.10",
+        "@chris.troutner/retry-queue": "1.0.11",
         "@helia/unixfs": "3.0.7",
         "@libp2p/bootstrap": "10.1.5",
         "@libp2p/circuit-relay-v2": "1.1.5",
@@ -2590,9 +2590,9 @@
       "license": "ISC"
     },
     "node_modules/@chris.troutner/retry-queue": {
-      "version": "1.0.10",
-      "resolved": "http://94.130.170.209:4873/@chris.troutner%2fretry-queue/-/retry-queue-1.0.10.tgz",
-      "integrity": "sha512-iF+xQl3jyTATAKDVkwY85j4Npihh/MqG99bjrS0cNJDF0XQeUSMVGsdtXR6TFj8YcEgfPvgBdYGOtEFo6tTQpA==",
+      "version": "1.0.11",
+      "resolved": "http://94.130.170.209:4873/@chris.troutner%2fretry-queue/-/retry-queue-1.0.11.tgz",
+      "integrity": "sha512-IJt19IdG4oy20PnHvRHn1bPrMHCwzPuL2R8Ze13VbaKQXKYjcBV5neARn/TQJ/V2It1z2OkV0qj/sJV7scahaA==",
       "license": "MIT",
       "dependencies": {
         "p-queue": "7.3.0",
@@ -12880,6 +12880,16 @@
       },
       "peerDependencies": {
         "libp2p": ">=1.9.1"
+      }
+    },
+    "node_modules/helia-coord/node_modules/@chris.troutner/retry-queue": {
+      "version": "1.0.10",
+      "resolved": "http://94.130.170.209:4873/@chris.troutner%2fretry-queue/-/retry-queue-1.0.10.tgz",
+      "integrity": "sha512-iF+xQl3jyTATAKDVkwY85j4Npihh/MqG99bjrS0cNJDF0XQeUSMVGsdtXR6TFj8YcEgfPvgBdYGOtEFo6tTQpA==",
+      "license": "MIT",
+      "dependencies": {
+        "p-queue": "7.3.0",
+        "p-retry": "5.1.1"
       }
     },
     "node_modules/helia-coord/node_modules/uuid": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17028,6 +17028,7 @@
       "resolved": "http://94.130.170.209:4873/mkdirp/-/mkdirp-0.5.6.tgz",
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -26319,6 +26320,7 @@
       "resolved": "http://94.130.170.209:4873/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
       "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.11",
         "imurmurhash": "^0.1.4",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@chainsafe/libp2p-gossipsub": "13.1.1",
     "@chainsafe/libp2p-noise": "15.1.1",
     "@chainsafe/libp2p-yamux": "6.0.2",
-    "@chris.troutner/retry-queue": "1.0.10",
+    "@chris.troutner/retry-queue": "1.0.11",
     "@helia/unixfs": "3.0.7",
     "@libp2p/bootstrap": "10.1.5",
     "@libp2p/circuit-relay-v2": "1.1.5",

--- a/src/controllers/timer-controllers.js
+++ b/src/controllers/timer-controllers.js
@@ -31,8 +31,8 @@ class TimerControllers {
     this.autoReboot = this.autoReboot.bind(this)
 
     // Encapsulate constants
-    this.PIN_CID_INTERVAL = 60000 * 12 // 12 minutes
-    this.REBOOT_INTERVAL = 60000 * 60 * 3 // 3 hours
+    this.PIN_CID_INTERVAL = 60000 * 32 // 32 minutes
+    this.REBOOT_INTERVAL = 60000 * 60 * 4 // 4 hours
   }
 
   // Start all the time-based controllers.

--- a/src/controllers/timer-controllers.js
+++ b/src/controllers/timer-controllers.js
@@ -31,7 +31,7 @@ class TimerControllers {
     this.autoReboot = this.autoReboot.bind(this)
 
     // Encapsulate constants
-    this.PIN_CID_INTERVAL = 60000 * 30 // 5 minutes
+    this.PIN_CID_INTERVAL = 60000 * 12 // 12 minutes
     this.REBOOT_INTERVAL = 60000 * 60 * 3 // 3 hours
   }
 

--- a/src/use-cases/ipfs.js
+++ b/src/use-cases/ipfs.js
@@ -538,14 +538,18 @@ class IpfsUseCases {
   // This prevents _getCid from blocking downloads of other CIDs for too long.
   async _getCidWithTimeout (inObj = {}) {
     return new Promise((resolve, reject) => {
+      const { cid } = inObj
+
       // The Promise will reject after a period of time.
       const timeout = 60000 * 5 // 5 minutes
       const timer = setTimeout(() => {
+        console.log(`CID ${cid} did not finish downloading after ${timeout / 60000} minutes`)
         reject(new Error(`Operation timed out after ${timeout} ms`))
       }, timeout)
 
       this._getCid(inObj)
         .then((result) => {
+          console.log(`Finished downloading CID ${cid}`)
           // If the download is successful, then clear the timer and resolve with
           // the downloaded data.
           clearTimeout(timer)

--- a/src/use-cases/ipfs.js
+++ b/src/use-cases/ipfs.js
@@ -42,7 +42,7 @@ class IpfsUseCases {
     this.bchjs = this.wallet.bchjs
     this.retryQueue = new RetryQueue({
       concurrency: 20,
-      attempts: 0,
+      attempts: 1,
       timeout: 60000 * 5 // Note: Timeout feature does not work is v1.0.10
     })
     this.pinEntity = new PinEntity()

--- a/src/use-cases/ipfs.js
+++ b/src/use-cases/ipfs.js
@@ -42,7 +42,7 @@ class IpfsUseCases {
     this.bchjs = this.wallet.bchjs
     this.retryQueue = new RetryQueue({
       concurrency: 20,
-      attempts: 1,
+      attempts: 0,
       timeout: 60000 * 5 // Note: Timeout feature does not work is v1.0.10
     })
     this.pinEntity = new PinEntity()

--- a/src/use-cases/ipfs.js
+++ b/src/use-cases/ipfs.js
@@ -618,7 +618,7 @@ class IpfsUseCases {
 
       const Pins = this.adapters.localdb.Pins
       const existingModel = await Pins.find({ cid })
-      // console.log('existingModel: ', existingModel)
+      console.log(`existingModel for CID ${cid}: `, existingModel)
 
       return existingModel[0]
     } catch (err) {

--- a/src/use-cases/ipfs.js
+++ b/src/use-cases/ipfs.js
@@ -42,7 +42,8 @@ class IpfsUseCases {
     this.bchjs = this.wallet.bchjs
     this.retryQueue = new RetryQueue({
       concurrency: 20,
-      timeout: 60000 * 5 // 5 minute timeout
+      attempts: 1,
+      timeout: 60000 * 5 // Note: Timeout feature does not work is v1.0.10
     })
     this.pinEntity = new PinEntity()
     this.CID = CID


### PR DESCRIPTION
The code changes in this PR center around the re-processing of Pin Claims within the Timer Controller. This PR fixes a few bugs with that processing.

The bug centers around an issue that was observed. When the list of un-downloaded CIDs gets long enough, it blocks new entries from being downloaded and resolved.

These changes remove retries from the queue of downloads, as well as a download timeout of 5 minutes. If a CID fails to download in 5 minutes, it is moved to the back of the queue. In this way the entire queue has a chance to get processed, whereas before it was not.