### PR TITLE
Fix bug with Timer Controller

### DIFF
--- a/src/controllers/timer-controllers.js
+++ b/src/controllers/timer-controllers.js
@@ -31,7 +31,8 @@ class TimerControllers {
     this.autoReboot = this.autoReboot.bind(this)
 
     // Encapsulate constants
-    this.PIN_CID_INTERVAL = 60000 * 32 // 32 minutes
+    // this.PIN_CID_INTERVAL = 60000 * 32 // 32 minutes
+    this.PIN_CID_INTERVAL = 60000 * 12 // 12 minutes
     this.REBOOT_INTERVAL = 60000 * 60 * 4 // 4 hours
   }
 

--- a/src/controllers/timer-controllers.js
+++ b/src/controllers/timer-controllers.js
@@ -31,8 +31,8 @@ class TimerControllers {
     this.autoReboot = this.autoReboot.bind(this)
 
     // Encapsulate constants
-    // this.PIN_CID_INTERVAL = 60000 * 32 // 32 minutes
-    this.PIN_CID_INTERVAL = 60000 * 12 // 12 minutes
+    this.PIN_CID_INTERVAL = 60000 * 32 // 32 minutes
+    // this.PIN_CID_INTERVAL = 60000 * 12 // 12 minutes
     this.REBOOT_INTERVAL = 60000 * 60 * 4 // 4 hours
   }
 

--- a/src/controllers/timer-controllers.js
+++ b/src/controllers/timer-controllers.js
@@ -31,8 +31,8 @@ class TimerControllers {
     this.autoReboot = this.autoReboot.bind(this)
 
     // Encapsulate constants
-    this.PIN_CID_INTERVAL = 60000 * 32 // 32 minutes
-    // this.PIN_CID_INTERVAL = 60000 * 12 // 12 minutes
+    // this.PIN_CID_INTERVAL = 60000 * 32 // 32 minutes
+    this.PIN_CID_INTERVAL = 60000 * 12 // 12 minutes
     this.REBOOT_INTERVAL = 60000 * 60 * 4 // 4 hours
   }
 

--- a/src/use-cases/ipfs.js
+++ b/src/use-cases/ipfs.js
@@ -511,8 +511,20 @@ class IpfsUseCases {
 
     try {
       console.log(`Trying to download CID ${cid}...`)
-      await this.adapters.ipfs.ipfs.blockstore.get(cid)
 
+      // This command seems to be hanging and not downloading the files.
+      // await this.adapters.ipfs.ipfs.blockstore.get(cid)
+
+      // Trying alternate way to download file
+      const fs = this.adapters.ipfs.ipfs.fs
+      const chunks = []
+      for await (const buf of fs.cat(cid)) {
+        // console.info(buf)
+        chunks.push(buf)
+      }
+      console.log(`CID ${cid} downloaded successfully. chunks.length: ${chunks.length}`)
+
+      // Get the file size and other stats on the file.
       const stats = await this.adapters.ipfs.ipfs.fs.stat(cid)
       // console.log('file stats: ', stats)
 

--- a/src/use-cases/ipfs.js
+++ b/src/use-cases/ipfs.js
@@ -358,6 +358,18 @@ class IpfsUseCases {
       // const fileSize = await this._getCid({ cid: cidClass })
       console.log(`File size for ${cid}: `, fileSize)
 
+      // If filesize is undefined, then the download was not successful.
+      //
+      if (!fileSize && fileSize !== 0) {
+        // console.log(`Download of ${filename} (${cid}) failed. Removing from tracker for retry.`)
+        delete this.pinTracker[cid]
+        this.pinTrackerCnt--
+
+        return false
+      }
+
+      // Dev Note: This call to pin content must come AFTER the CID is downloaded,
+      // otherwise the Promise returned from pin.add() will never resolve.
       // If the model in the database says the file is already pinned and
       // validated, then ensure the file is actually pinned and exit.
       if (dataPinned) {
@@ -376,15 +388,7 @@ class IpfsUseCases {
         return true
       }
 
-      // If filesize is undefined, then the download was not successful.
-      //
-      if (!fileSize && fileSize !== 0) {
-        // console.log(`Download of ${filename} (${cid}) failed. Removing from tracker for retry.`)
-        delete this.pinTracker[cid]
-        this.pinTrackerCnt--
 
-        return false
-      }
 
       // const file = await this.adapters.ipfs.ipfs.blockstore.get(cidClass)
       // console.log('pinCid() file: ', file)

--- a/src/use-cases/ipfs.js
+++ b/src/use-cases/ipfs.js
@@ -367,11 +367,11 @@ class IpfsUseCases {
           await this.adapters.ipfs.ipfs.pins.add(cidClass)
           console.log(`...finished pinning ${cid}`)
         } catch (err) {
-          // if (err.message.includes('Already pinned')) {
-          //   console.log(`CID ${cid} already pinned.`)
-          // } else {
-          //   throw err
-          // }
+          if (err.message.includes('Already pinned')) {
+            console.log(`CID ${cid} already pinned.`)
+          } else {
+            throw err
+          }
         }
         return true
       }

--- a/src/use-cases/ipfs.js
+++ b/src/use-cases/ipfs.js
@@ -354,6 +354,9 @@ class IpfsUseCases {
       // the same file twice.
       const tracker = this.trackPin(cid)
 
+      const fileSize = await this.retryQueue.addToQueue(this._getCidWithTimeout, { cid: cidClass })
+      // const fileSize = await this._getCid({ cid: cidClass })
+
       // If the model in the database says the file is already pinned and
       // validated, then ensure the file is actually pinned and exit.
       if (dataPinned) {
@@ -369,9 +372,6 @@ class IpfsUseCases {
         }
         return true
       }
-
-      const fileSize = await this.retryQueue.addToQueue(this._getCidWithTimeout, { cid: cidClass })
-      // const fileSize = await this._getCid({ cid: cidClass })
 
       // If filesize is undefined, then the download was not successful.
       //

--- a/src/use-cases/ipfs.js
+++ b/src/use-cases/ipfs.js
@@ -356,13 +356,16 @@ class IpfsUseCases {
 
       const fileSize = await this.retryQueue.addToQueue(this._getCidWithTimeout, { cid: cidClass })
       // const fileSize = await this._getCid({ cid: cidClass })
+      console.log(`File size for ${cid}: `, fileSize)
 
       // If the model in the database says the file is already pinned and
       // validated, then ensure the file is actually pinned and exit.
       if (dataPinned) {
         // Pin the file
         try {
+          console.log(`Pinning ${cid}...`)
           await this.adapters.ipfs.ipfs.pins.add(cidClass)
+          console.log(`...finished pinning ${cid}`)
         } catch (err) {
           // if (err.message.includes('Already pinned')) {
           //   console.log(`CID ${cid} already pinned.`)

--- a/src/use-cases/ipfs.js
+++ b/src/use-cases/ipfs.js
@@ -377,7 +377,7 @@ class IpfsUseCases {
         try {
           console.log(`Pinning ${cid}...`)
           await this.adapters.ipfs.ipfs.pins.add(cidClass)
-          console.log(`...finished pinning ${cid}`)
+          console.log(`...finished pinning ${cid}\n`)
         } catch (err) {
           if (err.message.includes('Already pinned')) {
             console.log(`CID ${cid} already pinned.`)
@@ -421,7 +421,7 @@ class IpfsUseCases {
         }
 
         this.pinSuccess++
-        console.log(`Pinned file ${cid}. ${this.pinSuccess} files successfully pinned.`)
+        console.log(`Pinned file ${cid}. ${this.pinSuccess} files successfully pinned.\n`)
 
         pinData.dataPinned = true
         pinData.validClaim = true

--- a/src/use-cases/ipfs.js
+++ b/src/use-cases/ipfs.js
@@ -513,16 +513,17 @@ class IpfsUseCases {
       console.log(`Trying to download CID ${cid}...`)
 
       // This command seems to be hanging and not downloading the files.
-      // await this.adapters.ipfs.ipfs.blockstore.get(cid)
+      await this.adapters.ipfs.ipfs.blockstore.get(cid)
 
+      // This way throws a 'not a file' error when processing Token Tiger JSON files.
       // Trying alternate way to download file
-      const fs = this.adapters.ipfs.ipfs.fs
-      const chunks = []
-      for await (const buf of fs.cat(cid)) {
-        // console.info(buf)
-        chunks.push(buf)
-      }
-      console.log(`CID ${cid} downloaded successfully. chunks.length: ${chunks.length}`)
+      // const fs = this.adapters.ipfs.ipfs.fs
+      // const chunks = []
+      // for await (const buf of fs.cat(cid)) {
+      //   // console.info(buf)
+      //   chunks.push(buf)
+      // }
+      // console.log(`CID ${cid} downloaded successfully. chunks.length: ${chunks.length}`)
 
       // Get the file size and other stats on the file.
       const stats = await this.adapters.ipfs.ipfs.fs.stat(cid)

--- a/src/use-cases/ipfs.js
+++ b/src/use-cases/ipfs.js
@@ -388,8 +388,6 @@ class IpfsUseCases {
         return true
       }
 
-
-
       // const file = await this.adapters.ipfs.ipfs.blockstore.get(cidClass)
       // console.log('pinCid() file: ', file)
       // fileSize = file.length


### PR DESCRIPTION
This PR fixes a bug in the Timer Controller that tries to re-download, pin, and validate pin claims that may have failed their initial download attempt.

This bug was keeping several instances of ipfs-file-pin-service from syncing. The root cause was the order of operations. Calling `pin.add()` before calling `fs.get()` caused the IPFS node to never resolve its promise. Changing the order of operations made it run fine. There was no error or timeout, so that was why it was hard to detect.