### PR TITLE
Adding pagination and file size

### DIFF
--- a/src/adapters/localdb/models/pins.js
+++ b/src/adapters/localdb/models/pins.js
@@ -20,7 +20,8 @@ const Pin = new mongoose.Schema({
   dataPinned: { type: Boolean, default: false },
   address: { type: String, default: null },
   recordTime: { type: Number },
-  downloadTries: { type: Number, default: 0 }
+  downloadTries: { type: Number, default: 0 },
+  fileSize: { type: Number, default: null } // Size in bytes
 })
 
 export default mongoose.model('pin', Pin)

--- a/src/controllers/rest-api/ipfs/controller.js
+++ b/src/controllers/rest-api/ipfs/controller.js
@@ -245,19 +245,21 @@ class IpfsRESTControllerLib {
   }
 
   /**
-   * @api {get} /ipfs/pins Get metadata on the the last 20 pinned items
+   * @api {get} /ipfs/pins/:page Get metadata on pinned items
    * @apiPermission public
    * @apiName GetPins
    * @apiGroup REST IPFS
    *
    * @apiExample Example usage:
-   * curl -H "Content-Type: application/json" -X GET localhost:5031/ipfs/pins
+   * curl -H "Content-Type: application/json" -X GET localhost:5031/ipfs/pins/1
    *
    */
   // Get a paginated list of the latest pin claims.
   async getPins (ctx) {
     try {
-      const pins = await this.useCases.ipfs.getPinClaims()
+      const { page } = ctx.params
+
+      const pins = await this.useCases.ipfs.getPinClaims({ page })
 
       ctx.body = pins
     } catch (err) {

--- a/src/controllers/rest-api/ipfs/index.js
+++ b/src/controllers/rest-api/ipfs/index.js
@@ -62,7 +62,7 @@ class IpfsRouter {
     this.router.get('/node', this.ipfsRESTController.getThisNode)
     this.router.get('/view/:cid', this.ipfsRESTController.viewFile)
     this.router.get('/view/:cid/:name', this.ipfsRESTController.viewFile)
-    this.router.get('/pins', this.ipfsRESTController.getPins)
+    this.router.get('/pins/:page', this.ipfsRESTController.getPins)
 
     // Attach the Controller routes to the Koa app.
     app.use(this.router.routes())

--- a/src/use-cases/ipfs.js
+++ b/src/use-cases/ipfs.js
@@ -278,6 +278,9 @@ class IpfsUseCases {
         // this.pinTrackerCnt--
 
         return false
+      } else {
+        pinData.fileSize = fileSize
+        await pinData.save()
       }
 
       // const file = await this.adapters.ipfs.ipfs.blockstore.get(cidClass)


### PR DESCRIPTION
This PR adds two new features:
- The GET /pins endpoint has been refactored to GET /pin/:page. It now returns paginated results based on the page value.
- Database models for Pin Claims now record the file size in the database model.